### PR TITLE
Activate Vibinex Code Review App

### DIFF
--- a/.github/workflows/repo-profiler.yml
+++ b/.github/workflows/repo-profiler.yml
@@ -1,0 +1,14 @@
+on:
+  repository_dispatch:
+    types: repo_profile_execution
+jobs:
+  profile:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Repository Profiler
+        uses: Alokit-Innovations/repo-profiler@main


### PR DESCRIPTION
This public repository of yours has the Vibinex GitHub App installed but is not activated unless you add this GitHub Action to it as well. 

We are working on a self-hosted server solution to this which will be released next week.